### PR TITLE
Add ability for @async_generator to create a native async generator

### DIFF
--- a/async_generator/__init__.py
+++ b/async_generator/__init__.py
@@ -7,11 +7,18 @@ from ._impl import (
     isasyncgenfunction,
     get_asyncgen_hooks,
     set_asyncgen_hooks,
+    supports_native_asyncgens,
 )
 from ._util import aclosing, asynccontextmanager
+from functools import partial as _partial
+
+async_generator_native = _partial(async_generator, allow_native=True)
+async_generator_legacy = _partial(async_generator, allow_native=False)
 
 __all__ = [
     "async_generator",
+    "async_generator_native",
+    "async_generator_legacy",
     "yield_",
     "yield_from_",
     "aclosing",
@@ -20,4 +27,5 @@ __all__ = [
     "asynccontextmanager",
     "get_asyncgen_hooks",
     "set_asyncgen_hooks",
+    "supports_native_asyncgens",
 ]

--- a/async_generator/_tests/conftest.py
+++ b/async_generator/_tests/conftest.py
@@ -34,3 +34,41 @@ def pytest_pyfunc_call(pyfuncitem):
                 pass
 
         pyfuncitem.obj = wrapper
+
+
+# On CPython 3.6+, tests that accept an 'async_generator' fixture
+# will be called twice, once to test behavior with legacy pure-Python
+# async generators (i.e. _impl.AsyncGenerator) and once to test behavior
+# with wrapped native async generators. Tests should decorate their
+# asyncgens with their local @async_generator, and may inspect
+# async_generator.is_native to know which sort is being used.
+# On CPython 3.5 or PyPy, where native async generators do not
+# exist, async_generator will always call _impl.async_generator()
+# and tests will be invoked only once.
+
+from .. import supports_native_asyncgens
+maybe_native = pytest.param(
+    "native",
+    marks=pytest.mark.skipif(
+        not supports_native_asyncgens,
+        reason="native async generators are not supported on this Python version"
+    )
+)
+
+
+@pytest.fixture(params=["legacy", maybe_native])
+def async_generator(request):
+    from .. import async_generator as real_async_generator
+
+    def wrapper(afn=None, *, uses_return=False):
+        if afn is None:
+            return partial(wrapper, uses_return=uses_return)
+        if request.param == "native":
+            return real_async_generator(afn, allow_native=True)
+        # make sure the uses_return= argument matches what async_generator detects
+        real_async_generator(afn, allow_native=False, uses_return=uses_return)
+        # make sure autodetection without uses_return= works too
+        return real_async_generator(afn, allow_native=False)
+
+    wrapper.is_native = request.param == "native"
+    return wrapper

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -117,6 +117,98 @@ support for ``yield from`` and for returning non-None values from
 an async generator (under the theory that these may well be added
 to native async generators one day).
 
+There are actually two implementations of the ``@async_generator``
+decorator internally:
+
+* ``@async_generator_legacy`` (or ``@async_generator(allow_native=False)``)
+  always uses the pure-Python version that requires no interpreter
+  support beyond basic async/await. It is rather slow for yield-bound
+  workloads (see :ref:`perf`), but supports PyPy, CPython 3.5, and
+  async generators that return non-None values.
+
+* ``@async_generator_native`` (or ``@async_generator(allow_native=True)``)
+  uses some ``co_flags`` trickery to create a *native* async generator
+  where possible, with 3.5-compatible syntax but closer to 3.6-native
+  performance (and some minor semantic differences, described below).
+  Native async generators can only be created on CPython 3.6+ and only
+  for functions that never return values other than None; if these
+  conditions are not met, ``@async_generator_native`` silently behaves
+  like ``@async_generator_legacy``.
+
+Currently, ``@async_generator`` behaves like ``@async_generator_legacy``,
+and also emits warnings if the resulting generator is used in a way
+that would produce different results under ``@async_generator_native``.
+The next release of this library will change the default to
+``@async_generator_native``.
+
+There are a couple of known differences between the semantics of the
+two implementations:
+
+* Native async generators suffer from a `bug <https://bugs.python.org/issue32526>`__
+  where they will not be considered "running" if the generator has
+  awaited some async function that is currently suspended in the
+  event loop. Thus, you can start a second ``asend()`` call (or similar)
+  before the first one completes, resulting in behavior that is extremely
+  confusing at best. The legacy implementation does not have this quirk,
+  and will throw an exception on any attempt to reenter the generator.
+
+* Native async generators provide a rather unhelpful error message if
+  they are garbage-collected with no :ref:`finalizer <finalization>` installed
+  and some async operations to perform during stack unwinding: they say
+  "async generator ignored GeneratorExit", the same as if the generator
+  tried to ``yield`` in a ``finally:`` block. The legacy implementation
+  provides a clearer error that describes the possible remedies.
+
+Both types of ``@async_generator`` behave the same with respect to
+:ref:`finalization semantics <finalization>`, :ref:`yield_from interoperability
+with native generators <yieldfrom>`, and so on; you don't need to use
+``@async_generator_native`` for those if you're on 3.6.
+
+The value ``async_generator.supports_native_asyncgens`` will be True
+if we're running on a platform where the above-described tricks are
+possible.
+
+.. note::
+   Producing a native async generator requires this library to determine
+   whether an async function being decorated with ``@async_generator`` might
+   return something other than None. (Returns with an argument are
+   syntactically forbidden in native async generators, and if through
+   trickery we were to manage to execute one, the interpreter would probably
+   crash.) Normally the presence of such returns is autodetected through
+   some fairly straightforward bytecode inspection, but it's possible to
+   verify that the check is behaving as you expect: if you decorate a
+   function with ``@async_generator(uses_return=True)`` and it doesn't
+   appear to have non-None returns, or with
+   ``@async_generator(uses_return=False)`` and it does, the decorator
+   will throw a RuntimeError.
+
+
+.. _perf:
+
+Performance
+~~~~~~~~~~~
+
+`PEP 525 <https://www.python.org/dev/peps/pep-0525/#improvements-over-asynchronous-iterators>`__
+includes a microbenchmark demonstrating that a yield-bound async
+generator (that yields out ten million integers without awaiting
+anything) runs 2.3x faster than the equivalent async iterator.
+The pure-Python version of ``@async_generator`` cannot claim such
+improvements; it's about 10x *slower* than the async iterator on
+that workload. On the other hand, the version that produces a native
+async generator with ``await yield_(...)`` calls is only about 1.7x
+slower than the async iterator (4.3x slower than a backwards-incompatible
+fully native async generator); the overhead appears to be entirely
+due to the two extra async function calls that must be executed per
+``yield_`` compared to a native ``yield``.
+
+When considering these numbers, remember that most async generators
+are not yield-bound; if they didn't have to wait for something to
+happen in the event loop, they probably wouldn't be async! (Pure
+Python ``@async_generator`` functions do add a bit of overhead per
+event loop trap as well, but native ones do not.)
+
+
+.. _finalization:
 
 Garbage collection hooks
 ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This improves performance and offers cleaner tracebacks, although native generators continue to have the failure mode of https://bugs.python.org/issue32526 and to provide not-very-clear exception messages when they're misused.

Since the semantics of native async generators are slightly different, this change has `@async_generator` continue to produce an old-style pure-Python AsyncGenerator by default, with warnings if it looks like bpo-32526 would change the behavior of code that's using the async generator. Users can say `@async_generator_legacy` to continue to get the old behavior without the warnings, or `@async_generator_native` to use a native generator where available; my thought is that the next release of async_generator can make `@async_generator_native` be the default.

Also add an `ag_await` attribute to legacy async generators, to match the behavior of native ones.